### PR TITLE
Fixes #88 - Move Exception message to core

### DIFF
--- a/src/InstallationValidator.Core/Assets/Captions.cs
+++ b/src/InstallationValidator.Core/Assets/Captions.cs
@@ -110,35 +110,6 @@ namespace InstallationValidator.Core.Assets
    {
       public static readonly string CopyToClipboard = "Copy to Clipboard";
       public const string OutputNotDefined = "Output not defined!";
-
-      // TODO - change the implementation in Core and modify ExceptionView to use a RichEditControl instead of a label if the text does not display correctly
-      public static string ExceptionViewDescription(string issueTrackerUrl)
-      {
-         var sb = new StringBuilder();
-         appendLine("oops...something went terribly wrong.", sb);
-         appendLine(string.Empty, sb);
-         appendLine("To best address the error, please enter an issue in our issue tracker:", sb);
-         sb.Append("<ol>");
-         appendListItem($"Visit <b>{issueTrackerUrl}</b> or click on the link below", sb);
-         appendListItem("Click on the <b>New Issue</b> button", sb);
-         appendListItem("Describe the steps you took prior to the problem emerging", sb);
-         appendListItem($"Copy the information below by using the <b>{CopyToClipboard}</b> button and paste it in the issue description", sb);
-         appendListItem("if possible, attach your project file to the issue (do not attach confidential information)", sb);
-         sb.Append("</ol>");
-         appendLine(string.Empty, sb);
-         appendLine("Note: A GitHub account is required to create an issue", sb);
-         return sb.ToString();
-      }
-
-      private static void appendListItem(string listItem, StringBuilder sb)
-      {
-         sb.Append($"<li>{listItem}</li>");
-      }
-
-      private static void appendLine(string lineToAppend, StringBuilder sb)
-      {
-         sb.Append($"<p>{lineToAppend}</p>");
-      }
    }
 
    public static class Validation

--- a/src/InstallationValidator.Core/Extensions/LoggerPresenterExtensions.cs
+++ b/src/InstallationValidator.Core/Extensions/LoggerPresenterExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using InstallationValidator.Core.Assets;
 using InstallationValidator.Core.Presentation;
 using OSPSuite.Core.Extensions;
 
@@ -28,7 +27,7 @@ namespace InstallationValidator.Core.Extensions
       public static void LogException(this ILoggerPresenter presenter, Exception e, string issueTrackerUrl)
       {
          presenter.LogLine();
-         presenter.LogHTML(Exceptions.ExceptionViewDescription(issueTrackerUrl));
+         presenter.LogHTML(OSPSuite.Assets.Captions.ExceptionViewDescription(issueTrackerUrl));
          presenter.LogLine();
          presenter.LogLine(e.ExceptionMessageWithStackTrace());
          presenter.LogLine();

--- a/src/InstallationValidator.Core/InstallationValidator.Core.csproj
+++ b/src/InstallationValidator.Core/InstallationValidator.Core.csproj
@@ -85,24 +85,24 @@
       <HintPath>..\..\packages\NHibernate.4.1.1.4000\lib\net40\NHibernate.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OSPSuite.Assets, Version=7.1.0.81, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Assets.7.1.0.81\lib\net452\OSPSuite.Assets.dll</HintPath>
+    <Reference Include="OSPSuite.Assets, Version=7.1.0.82, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Assets.7.1.0.82\lib\net452\OSPSuite.Assets.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OSPSuite.Core, Version=7.1.0.81, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Core.7.1.0.81\lib\net452\OSPSuite.Core.dll</HintPath>
+    <Reference Include="OSPSuite.Core, Version=7.1.0.82, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Core.7.1.0.82\lib\net452\OSPSuite.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="OSPSuite.FuncParser, Version=0.0.0.0, Culture=neutral, processorArchitecture=x86">
       <HintPath>..\..\packages\OSPSuite.FuncParser.2.0.0.1\lib\net45\OSPSuite.FuncParser.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OSPSuite.Infrastructure, Version=7.1.0.81, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Infrastructure.7.1.0.81\lib\net452\OSPSuite.Infrastructure.dll</HintPath>
+    <Reference Include="OSPSuite.Infrastructure, Version=7.1.0.82, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Infrastructure.7.1.0.82\lib\net452\OSPSuite.Infrastructure.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OSPSuite.Presentation, Version=7.1.0.81, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Presentation.7.1.0.81\lib\net452\OSPSuite.Presentation.dll</HintPath>
+    <Reference Include="OSPSuite.Presentation, Version=7.1.0.82, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Presentation.7.1.0.82\lib\net452\OSPSuite.Presentation.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="OSPSuite.Serializer, Version=2.0.0.1, Culture=neutral, processorArchitecture=MSIL">

--- a/src/InstallationValidator.Core/packages.config
+++ b/src/InstallationValidator.Core/packages.config
@@ -10,12 +10,12 @@
   <package id="MathNet.Numerics" version="3.17.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NHibernate" version="4.1.1.4000" targetFramework="net452" />
-  <package id="OSPSuite.Assets" version="7.1.0.81" targetFramework="net452" />
-  <package id="OSPSuite.Core" version="7.1.0.81" targetFramework="net452" />
+  <package id="OSPSuite.Assets" version="7.1.0.82" targetFramework="net452" />
+  <package id="OSPSuite.Core" version="7.1.0.82" targetFramework="net452" />
   <package id="OSPSuite.DevExpress.Presentation" version="16.2.6" targetFramework="net452" />
   <package id="OSPSuite.FuncParser" version="2.0.0.1" targetFramework="net452" />
-  <package id="OSPSuite.Infrastructure" version="7.1.0.81" targetFramework="net452" />
-  <package id="OSPSuite.Presentation" version="7.1.0.81" targetFramework="net452" />
+  <package id="OSPSuite.Infrastructure" version="7.1.0.82" targetFramework="net452" />
+  <package id="OSPSuite.Presentation" version="7.1.0.82" targetFramework="net452" />
   <package id="OSPSuite.Serializer" version="2.0.0.1" targetFramework="net452" />
   <package id="OSPSuite.SimModel" version="2.0.0.12" targetFramework="net452" />
   <package id="OSPSuite.SmartXLS" version="2.6.3.3" targetFramework="net452" />

--- a/src/InstallationValidator/InstallationValidator.csproj
+++ b/src/InstallationValidator/InstallationValidator.csproj
@@ -206,12 +206,12 @@
       <HintPath>..\..\packages\Northwoods.GoWin.5.2.0\lib\net45\Northwoods.Go.Xml.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OSPSuite.Assets, Version=7.1.0.81, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Assets.7.1.0.81\lib\net452\OSPSuite.Assets.dll</HintPath>
+    <Reference Include="OSPSuite.Assets, Version=7.1.0.82, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Assets.7.1.0.82\lib\net452\OSPSuite.Assets.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OSPSuite.Core, Version=7.1.0.81, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Core.7.1.0.81\lib\net452\OSPSuite.Core.dll</HintPath>
+    <Reference Include="OSPSuite.Core, Version=7.1.0.82, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Core.7.1.0.82\lib\net452\OSPSuite.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="OSPSuite.DataBinding, Version=2.0.0.1, Culture=neutral, processorArchitecture=MSIL">
@@ -226,12 +226,12 @@
       <HintPath>..\..\packages\OSPSuite.FuncParser.2.0.0.1\lib\net45\OSPSuite.FuncParser.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OSPSuite.Infrastructure, Version=7.1.0.81, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Infrastructure.7.1.0.81\lib\net452\OSPSuite.Infrastructure.dll</HintPath>
+    <Reference Include="OSPSuite.Infrastructure, Version=7.1.0.82, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Infrastructure.7.1.0.82\lib\net452\OSPSuite.Infrastructure.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OSPSuite.Presentation, Version=7.1.0.81, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Presentation.7.1.0.81\lib\net452\OSPSuite.Presentation.dll</HintPath>
+    <Reference Include="OSPSuite.Presentation, Version=7.1.0.82, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Presentation.7.1.0.82\lib\net452\OSPSuite.Presentation.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="OSPSuite.Serializer, Version=2.0.0.1, Culture=neutral, processorArchitecture=MSIL">
@@ -246,8 +246,8 @@
       <HintPath>..\..\packages\OSPSuite.TeXReporting.2.0.0.4\lib\net45\OSPSuite.TeXReporting.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OSPSuite.UI, Version=7.1.0.81, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.UI.7.1.0.81\lib\net452\OSPSuite.UI.dll</HintPath>
+    <Reference Include="OSPSuite.UI, Version=7.1.0.82, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.UI.7.1.0.82\lib\net452\OSPSuite.UI.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="OSPSuite.Utility, Version=2.0.0.5, Culture=neutral, processorArchitecture=MSIL">

--- a/src/InstallationValidator/packages.config
+++ b/src/InstallationValidator/packages.config
@@ -11,20 +11,20 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NHibernate" version="4.1.1.4000" targetFramework="net452" />
   <package id="Northwoods.GoWin" version="5.2.0" targetFramework="net452" />
-  <package id="OSPSuite.Assets" version="7.1.0.81" targetFramework="net452" />
-  <package id="OSPSuite.Core" version="7.1.0.81" targetFramework="net452" />
+  <package id="OSPSuite.Assets" version="7.1.0.82" targetFramework="net452" />
+  <package id="OSPSuite.Core" version="7.1.0.82" targetFramework="net452" />
   <package id="OSPSuite.DataBinding" version="2.0.0.1" targetFramework="net452" />
   <package id="OSPSuite.DataBinding.DevExpress" version="2.0.0.3" targetFramework="net452" />
   <package id="OSPSuite.DevExpress" version="16.2.6" targetFramework="net452" />
   <package id="OSPSuite.DevExpress.Presentation" version="16.2.6" targetFramework="net452" />
   <package id="OSPSuite.FuncParser" version="2.0.0.1" targetFramework="net452" />
-  <package id="OSPSuite.Infrastructure" version="7.1.0.81" targetFramework="net452" />
-  <package id="OSPSuite.Presentation" version="7.1.0.81" targetFramework="net452" />
+  <package id="OSPSuite.Infrastructure" version="7.1.0.82" targetFramework="net452" />
+  <package id="OSPSuite.Presentation" version="7.1.0.82" targetFramework="net452" />
   <package id="OSPSuite.Serializer" version="2.0.0.1" targetFramework="net452" />
   <package id="OSPSuite.SimModel" version="2.0.0.12" targetFramework="net452" />
   <package id="OSPSuite.SmartXLS" version="2.6.3.3" targetFramework="net452" />
   <package id="OSPSuite.TeXReporting" version="2.0.0.4" targetFramework="net452" />
-  <package id="OSPSuite.UI" version="7.1.0.81" targetFramework="net452" />
+  <package id="OSPSuite.UI" version="7.1.0.82" targetFramework="net452" />
   <package id="OSPSuite.Utility" version="2.0.0.5" targetFramework="net452" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net452" />
   <package id="System.Data.SQLite.Core" version="1.0.105.0" targetFramework="net452" />

--- a/src/SimulationOutputComparer/SimulationOutputComparer.csproj
+++ b/src/SimulationOutputComparer/SimulationOutputComparer.csproj
@@ -197,12 +197,12 @@
       <HintPath>..\..\packages\Northwoods.GoWin.5.2.0\lib\net45\Northwoods.Go.Xml.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OSPSuite.Assets, Version=7.1.0.81, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Assets.7.1.0.81\lib\net452\OSPSuite.Assets.dll</HintPath>
+    <Reference Include="OSPSuite.Assets, Version=7.1.0.82, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Assets.7.1.0.82\lib\net452\OSPSuite.Assets.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OSPSuite.Core, Version=7.1.0.81, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Core.7.1.0.81\lib\net452\OSPSuite.Core.dll</HintPath>
+    <Reference Include="OSPSuite.Core, Version=7.1.0.82, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Core.7.1.0.82\lib\net452\OSPSuite.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="OSPSuite.DataBinding, Version=2.0.0.1, Culture=neutral, processorArchitecture=MSIL">
@@ -217,8 +217,8 @@
       <HintPath>..\..\packages\OSPSuite.FuncParser.2.0.0.1\lib\net45\OSPSuite.FuncParser.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OSPSuite.Presentation, Version=7.1.0.81, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Presentation.7.1.0.81\lib\net452\OSPSuite.Presentation.dll</HintPath>
+    <Reference Include="OSPSuite.Presentation, Version=7.1.0.82, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Presentation.7.1.0.82\lib\net452\OSPSuite.Presentation.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="OSPSuite.Serializer, Version=2.0.0.1, Culture=neutral, processorArchitecture=MSIL">
@@ -233,8 +233,8 @@
       <HintPath>..\..\packages\OSPSuite.TeXReporting.2.0.0.4\lib\net45\OSPSuite.TeXReporting.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OSPSuite.UI, Version=7.1.0.81, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.UI.7.1.0.81\lib\net452\OSPSuite.UI.dll</HintPath>
+    <Reference Include="OSPSuite.UI, Version=7.1.0.82, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.UI.7.1.0.82\lib\net452\OSPSuite.UI.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="OSPSuite.Utility, Version=2.0.0.5, Culture=neutral, processorArchitecture=MSIL">

--- a/src/SimulationOutputComparer/packages.config
+++ b/src/SimulationOutputComparer/packages.config
@@ -11,19 +11,19 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NHibernate" version="4.1.1.4000" targetFramework="net452" />
   <package id="Northwoods.GoWin" version="5.2.0" targetFramework="net452" />
-  <package id="OSPSuite.Assets" version="7.1.0.81" targetFramework="net452" />
-  <package id="OSPSuite.Core" version="7.1.0.81" targetFramework="net452" />
+  <package id="OSPSuite.Assets" version="7.1.0.82" targetFramework="net452" />
+  <package id="OSPSuite.Core" version="7.1.0.82" targetFramework="net452" />
   <package id="OSPSuite.DataBinding" version="2.0.0.1" targetFramework="net452" />
   <package id="OSPSuite.DataBinding.DevExpress" version="2.0.0.3" targetFramework="net452" />
   <package id="OSPSuite.DevExpress" version="16.2.6" targetFramework="net452" />
   <package id="OSPSuite.DevExpress.Presentation" version="16.2.6" targetFramework="net452" />
   <package id="OSPSuite.FuncParser" version="2.0.0.1" targetFramework="net452" />
-  <package id="OSPSuite.Presentation" version="7.1.0.81" targetFramework="net452" />
+  <package id="OSPSuite.Presentation" version="7.1.0.82" targetFramework="net452" />
   <package id="OSPSuite.Serializer" version="2.0.0.1" targetFramework="net452" />
   <package id="OSPSuite.SimModel" version="2.0.0.12" targetFramework="net452" />
   <package id="OSPSuite.SmartXLS" version="2.6.3.3" targetFramework="net452" />
   <package id="OSPSuite.TeXReporting" version="2.0.0.4" targetFramework="net452" />
-  <package id="OSPSuite.UI" version="7.1.0.81" targetFramework="net452" />
+  <package id="OSPSuite.UI" version="7.1.0.82" targetFramework="net452" />
   <package id="OSPSuite.Utility" version="2.0.0.5" targetFramework="net452" />
   <package id="WindowsAPICodePack-Core" version="1.1.2" targetFramework="net452" />
   <package id="WindowsAPICodePack-Shell" version="1.1.1" targetFramework="net452" />

--- a/tests/InstallationValidator.Tests/InstallationValidator.Tests.csproj
+++ b/tests/InstallationValidator.Tests/InstallationValidator.Tests.csproj
@@ -96,28 +96,28 @@
       <HintPath>..\..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OSPSuite.Assets, Version=7.1.0.81, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Assets.7.1.0.81\lib\net452\OSPSuite.Assets.dll</HintPath>
+    <Reference Include="OSPSuite.Assets, Version=7.1.0.82, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Assets.7.1.0.82\lib\net452\OSPSuite.Assets.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="OSPSuite.BDDHelper, Version=2.0.0.1, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\OSPSuite.BDDHelper.2.0.0.1\lib\net45\OSPSuite.BDDHelper.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OSPSuite.Core, Version=7.1.0.81, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Core.7.1.0.81\lib\net452\OSPSuite.Core.dll</HintPath>
+    <Reference Include="OSPSuite.Core, Version=7.1.0.82, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Core.7.1.0.82\lib\net452\OSPSuite.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="OSPSuite.FuncParser, Version=0.0.0.0, Culture=neutral, processorArchitecture=x86">
       <HintPath>..\..\packages\OSPSuite.FuncParser.2.0.0.1\lib\net45\OSPSuite.FuncParser.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OSPSuite.Infrastructure, Version=7.1.0.81, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Infrastructure.7.1.0.81\lib\net452\OSPSuite.Infrastructure.dll</HintPath>
+    <Reference Include="OSPSuite.Infrastructure, Version=7.1.0.82, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Infrastructure.7.1.0.82\lib\net452\OSPSuite.Infrastructure.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OSPSuite.Presentation, Version=7.1.0.81, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Presentation.7.1.0.81\lib\net452\OSPSuite.Presentation.dll</HintPath>
+    <Reference Include="OSPSuite.Presentation, Version=7.1.0.82, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Presentation.7.1.0.82\lib\net452\OSPSuite.Presentation.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="OSPSuite.Serializer, Version=2.0.0.1, Culture=neutral, processorArchitecture=MSIL">

--- a/tests/InstallationValidator.Tests/Presentation/MainPresenterSpecs.cs
+++ b/tests/InstallationValidator.Tests/Presentation/MainPresenterSpecs.cs
@@ -144,7 +144,7 @@ namespace InstallationValidator.Presentation
       [Observation]
       public void the_view_should_be_updated_with_exception_information()
       {
-         A.CallTo(() => _mainView.AppendHTML(Exceptions.ExceptionViewDescription(Constants.ISSUE_TRACKER_URL))).MustHaveHappened();
+         A.CallTo(() => _mainView.AppendHTML(OSPSuite.Assets.Captions.ExceptionViewDescription(Constants.ISSUE_TRACKER_URL))).MustHaveHappened();
       }
    }
 

--- a/tests/InstallationValidator.Tests/packages.config
+++ b/tests/InstallationValidator.Tests/packages.config
@@ -12,13 +12,13 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NHibernate" version="4.1.1.4000" targetFramework="net452" />
   <package id="NUnit" version="3.5.0" targetFramework="net452" />
-  <package id="OSPSuite.Assets" version="7.1.0.81" targetFramework="net452" />
+  <package id="OSPSuite.Assets" version="7.1.0.82" targetFramework="net452" />
   <package id="OSPSuite.BDDHelper" version="2.0.0.1" targetFramework="net452" />
-  <package id="OSPSuite.Core" version="7.1.0.81" targetFramework="net452" />
+  <package id="OSPSuite.Core" version="7.1.0.82" targetFramework="net452" />
   <package id="OSPSuite.DevExpress.Presentation" version="16.2.6" targetFramework="net452" />
   <package id="OSPSuite.FuncParser" version="2.0.0.1" targetFramework="net452" />
-  <package id="OSPSuite.Infrastructure" version="7.1.0.81" targetFramework="net452" />
-  <package id="OSPSuite.Presentation" version="7.1.0.81" targetFramework="net452" />
+  <package id="OSPSuite.Infrastructure" version="7.1.0.82" targetFramework="net452" />
+  <package id="OSPSuite.Presentation" version="7.1.0.82" targetFramework="net452" />
   <package id="OSPSuite.Serializer" version="2.0.0.1" targetFramework="net452" />
   <package id="OSPSuite.SimModel" version="2.0.0.12" targetFramework="net452" />
   <package id="OSPSuite.SmartXLS" version="2.6.3.3" targetFramework="net452" />


### PR DESCRIPTION
This is to take advantage of moving the newly formatted html message to core.