### PR TITLE
Fixes #107 - Refresh problem

### DIFF
--- a/src/InstallationValidator.Core/Services/BatchStarterTask.cs
+++ b/src/InstallationValidator.Core/Services/BatchStarterTask.cs
@@ -76,7 +76,7 @@ namespace InstallationValidator.Core.Services
          };
 
          using (var process = _startableProcessFactory.CreateStartableProcess(_applicationConfiguration.PKSimBatchToolPath, args))
-         using (var watcher = _logWatcherFactory.CreateLogWatcher(logFile))
+         using (var watcher = _logWatcherFactory.CreateLogWatcher(logFile, new [] {outputFolderPath}))
          {
             watcher.Watch();
             process.Start();

--- a/src/InstallationValidator.Core/Services/LogWatcherFactory.cs
+++ b/src/InstallationValidator.Core/Services/LogWatcherFactory.cs
@@ -1,9 +1,10 @@
-﻿using InstallationValidator.Core.Domain;
+﻿using System.Collections.Generic;
+using InstallationValidator.Core.Domain;
 
 namespace InstallationValidator.Core.Services
 {
    public interface ILogWatcherFactory
    {
-      ILogWatcher CreateLogWatcher(string logFile);
+      ILogWatcher CreateLogWatcher(string logFile, IEnumerable<string> additionalFoldersToWatch);
    }
 }

--- a/tests/InstallationValidator.Tests/Services/BatchStarterTaskSpecs.cs
+++ b/tests/InstallationValidator.Tests/Services/BatchStarterTaskSpecs.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using FakeItEasy;
 using InstallationValidator.Core;
@@ -32,7 +33,7 @@ namespace InstallationValidator.Services
          _startableProcess = A.Fake<StartableProcess>();
 
          A.CallTo(() => _startableProcessFactory.CreateStartableProcess(A<string>._, A<string[]>._)).Returns(_startableProcess);
-         A.CallTo(() => _logWatcherFactory.CreateLogWatcher(A<string>._)).Returns(_logWatcher);
+         A.CallTo(() => _logWatcherFactory.CreateLogWatcher(A<string>._, A<IEnumerable<string>>._)).Returns(_logWatcher);
       }
    }
 


### PR DESCRIPTION
Specify as many additional directories to watch for changes as required. A change in any of the additional directories triggers an update of the validation logger