### PR TITLE
Fix CodeQL configuration and warnings

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,8 +10,12 @@ on:
 
 env:
   MAJOR: 12
-  MINOR: 1
+  MINOR: 2
   RUN: ${{ github.run_number }}
+
+permissions:
+  contents: read
+  packages: read
 
 jobs:
 
@@ -29,7 +33,7 @@ jobs:
           dotnet restore
 
       - name: Build
-        run: dotnet build InstallationValidator.sln /p:Version=12.1.9999
+        run: dotnet build InstallationValidator.sln /p:Version=12.2.9999
 
       - name: Test
         run: dotnet test .\tests\**\bin\Debug\net472\InstallationValidator*Tests.dll --filter “TestCategory!=Reporting” --no-build -v normal  --logger:"html;LogFileName=../testLog_Windows.html"

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -1,5 +1,5 @@
-# Changing the workflow name will reset the run number
-name: Build Nightly 12.1
+name: Build Nightly 12.2
+run-name: Version 12.2.${{ github.run_number }}
 
 on:
   workflow_dispatch:
@@ -8,9 +8,13 @@ on:
 
 env:
   MAJOR: 12
-  MINOR: 1
+  MINOR: 2
   RUN: ${{ github.run_number }}
   TARGET_FRAMEWORK: net8
+
+permissions:
+  contents: read
+  packages: read
 
 jobs:
   get-latest-commit-timespan:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,23 @@
+name: "CodeQL Advanced"
+
+on:
+  push:
+    branches:
+    - develop
+    - main
+  pull_request:
+    branches:
+    - develop
+  workflow_dispatch:
+  schedule:
+    - cron: '40 3 * * 1' # Runs at 03:40 every monday
+
+jobs:
+  codeql:
+    uses: Open-Systems-Pharmacology/Workflows/.github/workflows/GitHub_CodeQL.yml@main
+    permissions:
+      # Match permissions required by the reusable workflow
+      security-events: write
+      packages: read
+    with:
+      languages: '["actions","csharp","ruby"]'


### PR DESCRIPTION
Fixes #311 Investigate CodeQL configuration warning
Fixes #310 Add explicit GHA permissions to avoid code scanning warnings
Fixes #307 build-nightly: add version to the run number

also incremented the build version 12.1=>12.2