### PR TITLE
Update core, dimensions and batch outputs

### DIFF
--- a/src/InstallationValidator.Core/InstallationValidator.Core.csproj
+++ b/src/InstallationValidator.Core/InstallationValidator.Core.csproj
@@ -24,15 +24,15 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.2.20" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.2.20" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.2.20" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.2.20" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.2.20" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.2.26" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.2.26" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.2.26" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.2.26" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.2.26" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.1" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.2.20" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.2.20" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2.26" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.2.26" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/InstallationValidator/InstallationValidator.csproj
+++ b/src/InstallationValidator/InstallationValidator.csproj
@@ -49,13 +49,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.2.20" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2.26" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.1" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.UI" Version="12.2.20" />
+    <PackageReference Include="OSPSuite.UI" Version="12.2.26" />
     <PackageReference Include="OSPSuite.DataBinding" Version="3.0.1.1" />
     <PackageReference Include="OSPSuite.DataBinding.Devexpress" Version="6.0.1.2" />
 

--- a/src/SimulationOutputComparer/SimulationOutputComparer.csproj
+++ b/src/SimulationOutputComparer/SimulationOutputComparer.csproj
@@ -49,13 +49,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.2.20" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2.26" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.1" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.UI" Version="12.2.20" />
+    <PackageReference Include="OSPSuite.UI" Version="12.2.26" />
 
     <PackageReference Include="OSPSuite.DataBinding" Version="3.0.1.1" />
     <PackageReference Include="OSPSuite.DataBinding.Devexpress" Version="6.0.1.2" />

--- a/tests/InstallationValidator.Tests/InstallationValidator.Tests.csproj
+++ b/tests/InstallationValidator.Tests/InstallationValidator.Tests.csproj
@@ -37,10 +37,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.2.20" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.2.20" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.2.20" />
-    <PackageReference Include="OSPSuite.UI" Version="12.2.20" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2.26" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.2.26" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.2.26" />
+    <PackageReference Include="OSPSuite.UI" Version="12.2.26" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />


### PR DESCRIPTION
Batch outputs were recalculated with 12.2, but all outputs were absolutely identical with the previous state, that's why they don't appear in the PR :)

<details><summary>Batch run log</summary>

```
Information: Starting batch run: 2026-01-09 13:59
Information: Found 88 files in 'C:\SW-Dev\InstallationValidator\data\Inputs\BatchFiles'
Information: Starting batch simulation export for file 'Beagle_SingleORAL_Dissolved.json'
Information: Loading simulation 'Beagle_SingleORAL_Dissolved' (1/3)...
Information: Loading simulation 'Beagle_SingleORAL_Dissolved_MW_200_fu_0.2_LogP_5' (2/3)...
Information: Loading simulation 'Beagle_SingleORAL_Dissolved_MW_800_fu_0.6_LogP_-5' (3/3)...
Information: 3 simulations found in file 'Beagle_SingleORAL_Dissolved.json'
Information: Starting batch simulation export for file 'Cattle_SingleIV.json'
Information: Loading simulation 'Cattle_SingleIV' (1/1)...
Information: 1 simulation found in file 'Cattle_SingleIV.json'
Information: Starting batch simulation export for file 'Cat_SingleORAL_Dissolved.json'
Information: Loading simulation 'Cat_SingleORAL_Dissolved' (1/1)...
Information: 1 simulation found in file 'Cat_SingleORAL_Dissolved.json'
Information: Starting batch simulation export for file 'CKD.json'
Information: Loading simulation 'CKD_Stage_3_PO' (1/3)...
Information: Loading simulation 'CKD_Stage_4_PO' (2/3)...
Information: Loading simulation 'CKD_Stage_5_PO' (3/3)...
Information: 3 simulations found in file 'CKD.json'
Information: Starting batch simulation export for file 'DDI_MultipleCombinations.json'
Information: Loading simulation '01_MM_Competitive_Competitive' (1/23)...
Information: Loading simulation '21_1st_Competitive_Competitive' (2/23)...
Information: Loading simulation '02_MM_Uncompetitive_Uncompetitive' (3/23)...
Information: Loading simulation '03_MM_Noncompetitive_Noncompetitive' (4/23)...
Information: Loading simulation '04_MM_Mixed_Mixed' (5/23)...
Information: Loading simulation '06_MM_Induction_Induction' (6/23)...
Information: Loading simulation '05_MM_Mechanismbased_Mechanismbased' (7/23)...
Information: Loading simulation '07_MM_Competitive_Competitive_Mechanismbased_Mechanismbased' (8/23)...
Information: Loading simulation '09_MM_Noncompetitive_Noncompetitive_Mechanismbased_Mechanismbased' (9/23)...
Information: Loading simulation '08_MM_Uncompetitive_Uncompetitive_Mechanismbased_Mechanismbased' (10/23)...
Information: Loading simulation '10_MM_Mixed_Mixed_Mechanismbased_Mechanismbased' (11/23)...
Information: Loading simulation '11_MM_Mechanismbased_Mechanismbased_Induction_Induction' (12/23)...
Information: Loading simulation '12_MM_All_DDI_Types' (13/23)...
Information: Loading simulation '23_1st_Noncompetitive_Noncompetitive' (14/23)...
Information: Loading simulation '24_1st_Mixed_Mixed' (15/23)...
Information: Loading simulation '25_1st_Mechanismbased_Mechanismbased' (16/23)...
Information: Loading simulation '26_1st_Induction_Induction' (17/23)...
Information: Loading simulation '27_1st_Competitive_Competitive_Mechanismbased_Mechanismbased' (18/23)...
Information: Loading simulation '28_1st_Uncompetitive_Uncompetitive_Mechanismbased_Mechanismbased' (19/23)...
Information: Loading simulation '29_1st_Noncompetitive_Noncompetitive_Mechanismbased_Mechanismbased' (20/23)...
Information: Loading simulation '30_1st_Mixed_Mixed_Mechanismbased_Mechanismbased' (21/23)...
Information: Loading simulation '31_1st_Mechanismbased_Mechanismbased_Induction_Induction' (22/23)...
Information: Loading simulation '32_1st_All_DDI_Types' (23/23)...
Information: 23 simulations found in file 'DDI_MultipleCombinations.json'
Information: Starting batch simulation export for file 'Dog_MultiORAL_12_12_Dissolved.json'
Information: Loading simulation 'Dog_MultiORAL_12_12_Dissolved' (1/1)...
Information: 1 simulation found in file 'Dog_MultiORAL_12_12_Dissolved.json'
Information: Starting batch simulation export for file 'Dog_MultiORAL_24_Dissolved.json'
Information: Loading simulation 'Dog_MultiORAL_24_Dissolved' (1/1)...
Information: 1 simulation found in file 'Dog_MultiORAL_24_Dissolved.json'
Information: Starting batch simulation export for file 'European_SingleORAL_Age_0_CYP3A4.json'
Information: Loading simulation 'European_SingleORAL_Age_0_CYP3A4' (1/1)...
Information: 1 simulation found in file 'European_SingleORAL_Age_0_CYP3A4.json'
Information: Starting batch simulation export for file 'European_SingleORAL_Age_0_GFR.json'
Information: Loading simulation 'European_SingleORAL_Age_0_GFR' (1/1)...
Information: 1 simulation found in file 'European_SingleORAL_Age_0_GFR.json'
Information: Starting batch simulation export for file 'European_SingleORAL_Age_1_CYP3A4.json'
Information: Loading simulation 'European_SingleORAL_Age_1_CYP3A4' (1/1)...
Information: 1 simulation found in file 'European_SingleORAL_Age_1_CYP3A4.json'
Information: Starting batch simulation export for file 'European_SingleORAL_Age_1_GFR.json'
Information: Loading simulation 'European_SingleORAL_Age_1_GFR' (1/1)...
Information: 1 simulation found in file 'European_SingleORAL_Age_1_GFR.json'
Information: Starting batch simulation export for file 'HI.json'
Information: Loading simulation 'Child-Pugh A' (1/3)...
Information: Loading simulation 'Child-Pugh B' (2/3)...
Information: Loading simulation 'Child-Pugh C' (3/3)...
Information: 3 simulations found in file 'HI.json'
Information: Starting batch simulation export for file 'Human_CompetitiveInhibition.json'
Information: Loading simulation 'Human_CompetitiveInhibition' (1/1)...
Information: 1 simulation found in file 'Human_CompetitiveInhibition.json'
Information: Starting batch simulation export for file 'Human_Healthy_Populations.json'
Information: Loading simulation 'Black_American_Female_Infusion' (1/24)...
Information: Loading simulation 'Black_American_Female_Oral' (2/24)...
Information: Loading simulation 'Black_American_Male_Infusion' (3/24)...
Information: Loading simulation 'Black_American_Male_Oral' (4/24)...
Information: Loading simulation 'EastAsian_Female_Infusion' (5/24)...
Information: Loading simulation 'EastAsian_Female_Oral' (6/24)...
Information: Loading simulation 'EastAsian_Male_Infusion' (7/24)...
Information: Loading simulation 'EastAsian_Male_Oral' (8/24)...
Information: Loading simulation 'ICRP_Elderly_Female_Infusion' (9/24)...
Information: Loading simulation 'ICRP_Elderly_Female_Oral' (10/24)...
Information: Loading simulation 'ICRP_Elderly_Male_Infusion' (11/24)...
Information: Loading simulation 'ICRP_Elderly_Male_Oral' (12/24)...
Information: Loading simulation 'Japanese_Female_Infusion' (13/24)...
Information: Loading simulation 'Japanese_Female_Oral' (14/24)...
Information: Loading simulation 'Japanese_Male_Infusion' (15/24)...
Information: Loading simulation 'Japanese_Male_Oral' (16/24)...
Information: Loading simulation 'Mexican_American_Female_Infusion' (17/24)...
Information: Loading simulation 'Mexican_American_Female_Oral' (18/24)...
Information: Loading simulation 'Mexican_American_Male_Infusion' (19/24)...
Information: Loading simulation 'Mexican_American_Male_Oral' (20/24)...
Information: Loading simulation 'White_American_Female_Infusion' (21/24)...
Information: Loading simulation 'White_American_Female_Oral' (22/24)...
Information: Loading simulation 'White_American_Male_Infusion' (23/24)...
Information: Loading simulation 'White_American_Male_Oral' (24/24)...
Information: 24 simulations found in file 'Human_Healthy_Populations.json'
Information: Starting batch simulation export for file 'Human_ICRP_AGP.json'
Information: Loading simulation '01_ICRP_0y_Male' (1/7)...
Information: Loading simulation '02_ICRP_0.05y_Female' (2/7)...
Information: Loading simulation '03_ICRP_0.18y_Male' (3/7)...
Information: Loading simulation '04_ICRP_1y_Female' (4/7)...
Information: Loading simulation '05_ICRP_12y_Male' (5/7)...
Information: Loading simulation '06_ICRP_30y_Female' (6/7)...
Information: Loading simulation '07_ICRP_100y_Male' (7/7)...
Information: 7 simulations found in file 'Human_ICRP_AGP.json'
Information: Starting batch simulation export for file 'Human_IrreversibleInhibition.json'
Information: Loading simulation 'Human_IrreversibleInhibition' (1/1)...
Information: 1 simulation found in file 'Human_IrreversibleInhibition.json'
Information: Starting batch simulation export for file 'Human_MixedInhibition.json'
Information: Loading simulation 'Human_MixedInhibition' (1/1)...
Information: 1 simulation found in file 'Human_MixedInhibition.json'
Information: Starting batch simulation export for file 'Human_MultiIV_6_6_12.json'
Information: Loading simulation 'Human_MultiIV_6_6_12' (1/1)...
Information: 1 simulation found in file 'Human_MultiIV_6_6_12.json'
Information: Starting batch simulation export for file 'Human_MultiORAL_6_12_12_Dissolved.json'
Information: Loading simulation 'Human_MultiORAL_6_12_12_Dissolved' (1/6)...
Information: Loading simulation 'Human_MultiORAL_6_12_12_Dissolved_EHC_continuous_fraction_0.5' (2/6)...
Information: Loading simulation 'Human_MultiORAL_6_12_12_Dissolved_EHC_continuous_fraction_1' (3/6)...
Information: Loading simulation 'Human_MultiORAL_6_12_12_Dissolved_absorption_sink_conditions' (4/6)...
Information: Loading simulation 'Human_MultiORAL_6_12_12_Dissolved_solubility' (5/6)...
Information: Loading simulation 'Human_MultiORAL_6_12_12_Dissolved_pKa-dependent penalty factor' (6/6)...
Information: 6 simulations found in file 'Human_MultiORAL_6_12_12_Dissolved.json'
Information: Starting batch simulation export for file 'Human_MultipleIV_Binding.json'
Information: Loading simulation 'Human_MultipleIV_Binding' (1/1)...
Information: 1 simulation found in file 'Human_MultipleIV_Binding.json'
Information: Starting batch simulation export for file 'Human_MultipleIV_Efflux.json'
Information: Loading simulation 'Human_MultipleIV_Efflux' (1/1)...
Information: 1 simulation found in file 'Human_MultipleIV_Efflux.json'
Information: Starting batch simulation export for file 'Human_MultipleIV_EffluxBasolateral.json'
Information: Loading simulation 'Human_MultipleIV_EffluxBasolateral' (1/1)...
Information: 1 simulation found in file 'Human_MultipleIV_EffluxBasolateral.json'
Information: Starting batch simulation export for file 'Human_MultipleIV_Influx.json'
Information: Loading simulation 'Human_MultipleIV_ActiveInflux' (1/1)...
Information: 1 simulation found in file 'Human_MultipleIV_Influx.json'
Information: Starting batch simulation export for file 'Human_MultipleIV_InfluxBasolateral.json'
Information: Loading simulation 'Human_MultipleIV_InfluxBasolateral' (1/1)...
Information: 1 simulation found in file 'Human_MultipleIV_InfluxBasolateral.json'
Information: Starting batch simulation export for file 'Human_MultipleIV_Metabolizm.json'
Information: Loading simulation 'Human_MultipleIV_Metabolizm' (1/1)...
Information: 1 simulation found in file 'Human_MultipleIV_Metabolizm.json'
Information: Starting batch simulation export for file 'Human_MultipleIV_MetabolizmBinding.json'
Information: Loading simulation 'Human_MultipleIV_MetabolizmBinding' (1/1)...
Information: 1 simulation found in file 'Human_MultipleIV_MetabolizmBinding.json'
Information: Starting batch simulation export for file 'Human_MultipleIV_PGP.json'
Information: Loading simulation 'Human_MultipleIV_PGP' (1/1)...
Information: 1 simulation found in file 'Human_MultipleIV_PGP.json'
Information: Starting batch simulation export for file 'Human_MultipleIV_PGPBasolateral.json'
Information: Loading simulation 'Human_MultipleIV_PGPBasolateral' (1/1)...
Information: 1 simulation found in file 'Human_MultipleIV_PGPBasolateral.json'
Information: Starting batch simulation export for file 'Human_NonCompetitiveInhibition.json'
Information: Loading simulation 'Human_NonCompetitiveInhibition' (1/1)...
Information: 1 simulation found in file 'Human_NonCompetitiveInhibition.json'
Information: Starting batch simulation export for file 'Human_Oral_BiDaily_TableFormulation.json'
Information: Loading simulation 'S1_suspension' (1/2)...
Information: Loading simulation 'S2_NoSuspension' (2/2)...
Information: 2 simulations found in file 'Human_Oral_BiDaily_TableFormulation.json'
Information: Starting batch simulation export for file 'Human_pH_SolubilityTable.json'
Information: Loading simulation 'S1_Table' (1/4)...
Information: Loading simulation 'S2_Measurement' (2/4)...
Information: Loading simulation 'S3_Table_SolubilityChanged' (3/4)...
Information: Loading simulation 'S4_Table_SolubilityTableChanged' (4/4)...
Information: 4 simulations found in file 'Human_pH_SolubilityTable.json'
Information: Starting batch simulation export for file 'Human_SingleIV.json'
Information: Loading simulation 'Human_SingleIV' (1/3)...
Information: Loading simulation 'Human_SingleIV_MW_200_fu_0.2_LogP_5' (2/3)...
Information: Loading simulation 'Human_SingleIV_MW_800_fu_0.6_LogP_-5' (3/3)...
Information: 3 simulations found in file 'Human_SingleIV.json'
Information: Starting batch simulation export for file 'Human_SingleIV_Configuration.json'
Information: Loading simulation 'Human_SingleIV_Configuration' (1/1)...
Information: 1 simulation found in file 'Human_SingleIV_Configuration.json'
Information: Starting batch simulation export for file 'Human_SingleORAL_Dissolved.json'
Information: Loading simulation 'Human_SingleORAL_Dissolved' (1/3)...
Information: Loading simulation 'Human_SingleORAL_Dissolved_MW_200_fu_0.2_LogP_5' (2/3)...
Information: Loading simulation 'Human_SingleORAL_Dissolved_MW_800_fu_0.6_LogP_-5' (3/3)...
Information: 3 simulations found in file 'Human_SingleORAL_Dissolved.json'
Information: Starting batch simulation export for file 'Human_SingleORAL_Dissolved_PlasmaClearance.json'
Information: Loading simulation 'Human_SingleORAL_Dissolved_PlasmaClearance' (1/3)...
Information: Loading simulation 'Human_SingleORAL_Dissolved_PlasmaClearance_MW_200_fu_0.2_LogP_5' (2/3)...
Information: Loading simulation 'Human_SingleORAL_Dissolved_PlasmaClearance_MW_800_fu_0.6_LogP_-5' (3/3)...
Information: 3 simulations found in file 'Human_SingleORAL_Dissolved_PlasmaClearance.json'
Information: Starting batch simulation export for file 'Human_SingleORAL_Lint80.json'
Information: Loading simulation 'Human_SingleORAL_Lint80' (1/1)...
Information: 1 simulation found in file 'Human_SingleORAL_Lint80.json'
Information: Starting batch simulation export for file 'Human_SingleORAL_Lint80_AsSuspention.json'
Information: Loading simulation 'Human_SingleORAL_Lint80_AsSuspention' (1/1)...
Information: 1 simulation found in file 'Human_SingleORAL_Lint80_AsSuspention.json'
Information: Starting batch simulation export for file 'Human_SingleORAL_MonoParticles_AsSuspention.json'
Information: Loading simulation 'Human_SingleORAL_MonoParticles_AsSuspention' (1/1)...
Information: 1 simulation found in file 'Human_SingleORAL_MonoParticles_AsSuspention.json'
Information: Starting batch simulation export for file 'Human_SingleORAL_PolyParticlesLogNormal_AsSuspention.json'
Information: Loading simulation 'Human_SingleORAL_PolyParticlesLogNormal_AsSuspention' (1/1)...
Information: 1 simulation found in file 'Human_SingleORAL_PolyParticlesLogNormal_AsSuspention.json'
Information: Starting batch simulation export for file 'Human_SingleORAL_PolyParticlesNormal_AsSuspention.json'
Information: Loading simulation 'Human_SingleORAL_PolyParticlesNormal_AsSuspention' (1/3)...
Information: Loading simulation 'Human_SingleORAL_PolyParticlesNormal_AsSuspention_dissolved_radius' (2/3)...
Information: Loading simulation 'Human_SingleORAL_PolyParticlesNormal_AsSuspention_treat_precipated_drug_as_soluble' (3/3)...
Information: 3 simulations found in file 'Human_SingleORAL_PolyParticlesNormal_AsSuspention.json'
Information: Starting batch simulation export for file 'Human_SingleORAL_Weibull.json'
Information: Loading simulation 'Human_SingleORAL_Weibull' (1/3)...
Information: Loading simulation 'Human_SingleORAL_Weibull_MW_200_fu_0.2_LogP_5' (2/3)...
Information: Loading simulation 'Human_SingleORAL_Weibull_MW_800_fu_0.6_LogP_-5' (3/3)...
Information: 3 simulations found in file 'Human_SingleORAL_Weibull.json'
Information: Starting batch simulation export for file 'Human_SingleORAL_Weibull_AsSuspention.json'
Information: Loading simulation 'Human_SingleORAL_Weibull_AsSuspention' (1/3)...
Information: Loading simulation 'Human_SingleORAL_Weibull_AsSuspention_MW_200_fu_0.2_LogP_5' (2/3)...
Information: Loading simulation 'Human_SingleORAL_Weibull_AsSuspention_MW_800_fu_0.6_LogP_-5' (3/3)...
Information: 3 simulations found in file 'Human_SingleORAL_Weibull_AsSuspention.json'
Information: Starting batch simulation export for file 'Human_UncompetitiveInhibition.json'
Information: Loading simulation 'Human_UncompetitiveInhibition' (1/1)...
Information: 1 simulation found in file 'Human_UncompetitiveInhibition.json'
Information: Starting batch simulation export for file 'Minipig_SingleORAL_Dissolved.json'
Information: Loading simulation 'Minipig_SingleORAL_Dissolved' (1/3)...
Information: Loading simulation 'Minipig_SingleORAL_Dissolved_MW_200_fu_0.2_LogP_5' (2/3)...
Information: Loading simulation 'Minipig_SingleORAL_Dissolved_MW_800_fu_0.6_LogP_-5' (3/3)...
Information: 3 simulations found in file 'Minipig_SingleORAL_Dissolved.json'
Information: Starting batch simulation export for file 'Monkey_SingleORAL_Dissolved.json'
Information: Loading simulation 'Monkey_SingleORAL_Dissolved' (1/3)...
Information: Loading simulation 'Monkey_SingleORAL_Dissolved_MW_200_fu_0.2_LogP_5' (2/3)...
Information: Loading simulation 'Monkey_SingleORAL_Dissolved_MW_800_fu_0.6_LogP_-5' (3/3)...
Information: 3 simulations found in file 'Monkey_SingleORAL_Dissolved.json'
Information: Starting batch simulation export for file 'Mouse_SingleORAL_Dissolved.json'
Information: Loading simulation 'Mouse_SingleORAL_Dissolved' (1/3)...
Information: Loading simulation 'Mouse_SingleORAL_Dissolved_MW_200_fu_0.2_LogP_5' (2/3)...
Information: Loading simulation 'Mouse_SingleORAL_Dissolved_MW_800_fu_0.6_LogP_-5' (3/3)...
Information: 3 simulations found in file 'Mouse_SingleORAL_Dissolved.json'
Information: Starting batch simulation export for file 'Preterm_SingleIV_Age_0_GA_32_CYP3A4.json'
Information: Loading simulation 'Preterm_SingleIV_Age_0_GA_32_CYP3A4' (1/1)...
Information: 1 simulation found in file 'Preterm_SingleIV_Age_0_GA_32_CYP3A4.json'
Information: Starting batch simulation export for file 'Preterm_SingleIV_Age_0_GA_32_GFR.json'
Information: Loading simulation 'Preterm_SingleIV_Age_0_GA_32_GFR' (1/1)...
Information: 1 simulation found in file 'Preterm_SingleIV_Age_0_GA_32_GFR.json'
Information: Starting batch simulation export for file 'Preterm_SingleIV_Age_15_GA_32_CYP3A4.json'
Information: Loading simulation 'Preterm_SingleIV_Age_15_GA_32_CYP3A4' (1/1)...
Information: 1 simulation found in file 'Preterm_SingleIV_Age_15_GA_32_CYP3A4.json'
Information: Starting batch simulation export for file 'Preterm_SingleIV_Age_15_GA_32_GFR.json'
Information: Loading simulation 'Preterm_SingleIV_Age_15_GA_32_GFR' (1/1)...
Information: 1 simulation found in file 'Preterm_SingleIV_Age_15_GA_32_GFR.json'
Information: Starting batch simulation export for file 'Rabbit_SingleORAL_Dissolved.json'
Information: Loading simulation 'Rabbit_SingleORAL_Dissolved' (1/3)...
Information: Loading simulation 'Rabbit_SingleORAL_Dissolved_MW_200_fu_0.2_LogP_5' (2/3)...
Information: Loading simulation 'Rabbit_SingleORAL_Dissolved_MW_800_fu_0.6_LogP_-5' (3/3)...
Information: 3 simulations found in file 'Rabbit_SingleORAL_Dissolved.json'
Information: Starting batch simulation export for file 'Rat_MultiORAL_6_6_12_Dissolved.json'
Information: Loading simulation 'Rat_MultiORAL_6_6_12_Dissolved' (1/1)...
Information: 1 simulation found in file 'Rat_MultiORAL_6_6_12_Dissolved.json'
Information: Starting batch simulation export for file 'Rat_MultiORAL_6_6_6_6_Dissolved.json'
Information: Loading simulation 'Rat_MultiORAL_6_6_6_6_Dissolved' (1/1)...
Information: 1 simulation found in file 'Rat_MultiORAL_6_6_6_6_Dissolved.json'
Information: Starting batch simulation export for file 'Rat_MultiORAL_8_8_8_Dissolved.json'
Information: Loading simulation 'Rat_MultiORAL_8_8_8_Dissolved' (1/1)...
Information: 1 simulation found in file 'Rat_MultiORAL_8_8_8_Dissolved.json'
Information: Starting batch simulation export for file 'SingleIV_2Pores_Human.json'
Information: Loading simulation 'SingleIV_2Pores_Human' (1/4)...
Information: Loading simulation 'SingleIV_2Pores_Human_SimulationC' (2/4)...
Information: Loading simulation 'SingleIV_2Pores_Human_SimulationD' (3/4)...
Information: Loading simulation 'SingleIV_2Pores_Human_SimulationF' (4/4)...
Information: 4 simulations found in file 'SingleIV_2Pores_Human.json'
Information: Starting batch simulation export for file 'SingleIV_2Pores_Monkey.json'
Information: Loading simulation 'SingleIV_2Pores_Monkey' (1/3)...
Information: Loading simulation 'SingleIV_2Pores_Monkey_SimulationG' (2/3)...
Information: Loading simulation 'SingleIV_2Pores_Monkey_SimulationH' (3/3)...
Information: 3 simulations found in file 'SingleIV_2Pores_Monkey.json'
Information: Starting batch simulation export for file 'SingleIV_2Pores_Mouse.json'
Information: Loading simulation 'SingleIV_2Pores_Mouse' (1/4)...
Information: Loading simulation 'SingleIV_2Pores_Mouse_SimulationA' (2/4)...
Information: Loading simulation 'SingleIV_2Pores_Mouse_SimulationB' (3/4)...
Information: Loading simulation 'SingleIV_2Pores_Mouse_SimulationE' (4/4)...
Information: 4 simulations found in file 'SingleIV_2Pores_Mouse.json'
Information: Starting batch simulation export for file 'SingleIV_C1_4Comp_standard_standard_standard.json'
Information: Loading simulation 'SingleIV_C1_4Comp_standard_standard_standard' (1/1)...
Information: 1 simulation found in file 'SingleIV_C1_4Comp_standard_standard_standard.json'
Information: Starting batch simulation export for file 'SingleIV_C2_4Comp_PT_standard_standard.json'
Information: Loading simulation 'SingleIV_C2_4Comp_PT_standard_standard' (1/1)...
Information: 1 simulation found in file 'SingleIV_C2_4Comp_PT_standard_standard.json'
Information: Starting batch simulation export for file 'SingleIV_C2_4Comp_RR_standard_standard.json'
Information: Loading simulation 'SingleIV_C2_4Comp_RR_standard_standard' (1/1)...
Information: 1 simulation found in file 'SingleIV_C2_4Comp_RR_standard_standard.json'
Information: Starting batch simulation export for file 'SingleIV_C2_4Comp_standard_schmitt_standard.json'
Information: Loading simulation 'SingleIV_C2_4Comp_standard_schmitt_standard' (1/1)...
Information: 1 simulation found in file 'SingleIV_C2_4Comp_standard_schmitt_standard.json'
Information: Starting batch simulation export for file 'SingleIV_C3_4Comp_RR_schmitt_standard.json'
Information: Loading simulation 'SingleIV_C3_4Comp_RR_schmitt_standard' (1/1)...
Information: 1 simulation found in file 'SingleIV_C3_4Comp_RR_schmitt_standard.json'
Information: Starting batch simulation export for file 'SingleIV_C3_4Comp_standard_schmittnormlized_standard.json'
Information: Loading simulation 'SingleIV_C3_4Comp_standard_schmittnormlized_standard' (1/1)...
Information: 1 simulation found in file 'SingleIV_C3_4Comp_standard_schmittnormlized_standard.json'
Information: Starting batch simulation export for file 'SingleIV_C4_2Pores_RR_standard_standard.json'
Information: Loading simulation 'SingleIV_C4_2Pores_RR_standard_standard' (1/1)...
Information: 1 simulation found in file 'SingleIV_C4_2Pores_RR_standard_standard.json'
Information: Starting batch simulation export for file 'SingleIV_C4_4Comp_Ber_standard_standard.json'
Information: Loading simulation 'SingleIV_C4_4Comp_Ber_standard_standard' (1/1)...
Information: 1 simulation found in file 'SingleIV_C4_4Comp_Ber_standard_standard.json'
Information: Starting batch simulation export for file 'SingleIV_C5_2Pores_Ber_standard_standard.json'
Information: Loading simulation 'SingleIV_C5_2Pores_Ber_standard_standard' (1/1)...
Information: 1 simulation found in file 'SingleIV_C5_2Pores_Ber_standard_standard.json'
Information: Starting batch simulation export for file 'SingleIV_C5_2Pores_PT_standard_standard.json'
Information: Loading simulation 'SingleIV_C5_2Pores_PT_standard_standard' (1/1)...
Information: 1 simulation found in file 'SingleIV_C5_2Pores_PT_standard_standard.json'
Information: Starting batch simulation export for file 'SingleIV_C5_2Pores_RR_schmitt_standard.json'
Information: Loading simulation 'SingleIV_C5_2Pores_RR_schmitt_standard' (1/1)...
Information: 1 simulation found in file 'SingleIV_C5_2Pores_RR_schmitt_standard.json'
Information: Starting batch simulation export for file 'SingleIV_C6_2Pores_standard_standard_standard.json'
Information: Loading simulation 'SingleIV_C6_2Pores_standard_standard_standard' (1/1)...
Information: 1 simulation found in file 'SingleIV_C6_2Pores_standard_standard_standard.json'
Information: Starting batch simulation export for file 'SingleIV_C7_2Pores_standard_schmitt_standard.json'
Information: Loading simulation 'SingleIV_C7_2Pores_standard_schmitt_standard' (1/1)...
Information: 1 simulation found in file 'SingleIV_C7_2Pores_standard_schmitt_standard.json'
Information: Starting batch simulation export for file 'SingleIV_C7_4Comp_schmitt_standard_standard.json'
Information: Loading simulation 'SingleIV_C7_4Comp_schmitt_standard_standard' (1/1)...
Information: 1 simulation found in file 'SingleIV_C7_4Comp_schmitt_standard_standard.json'
Information: Starting batch simulation export for file 'SingleIV_C8_2Pores_standard_schmittnormalized_standard.json'
Information: Loading simulation 'SingleIV_C8_2Pores_standard_schmittnormalized_standard' (1/1)...
Information: 1 simulation found in file 'SingleIV_C8_2Pores_standard_schmittnormalized_standard.json'
Information: Starting batch simulation export for file 'SingleIV_C9_2Pores_schmitt_standard_standard.json'
Information: Loading simulation 'SingleIV_C9_2Pores_schmitt_standard_standard' (1/1)...
Information: 1 simulation found in file 'SingleIV_C9_2Pores_schmitt_standard_standard.json'
Information: Starting batch simulation export for file 'SingleORAL_C10_4Comp_PT_standard_standard.json'
Information: Loading simulation 'SingleORAL_C10_4Comp_PT_standard_standard' (1/1)...
Information: 1 simulation found in file 'SingleORAL_C10_4Comp_PT_standard_standard.json'
Information: Starting batch simulation export for file 'SingleORAL_C11_4Comp_schmitt_standard_standard.json'
Information: Loading simulation 'SingleORAL_C11_4Comp_schmitt_standard_standard' (1/1)...
Information: 1 simulation found in file 'SingleORAL_C11_4Comp_schmitt_standard_standard.json'
Information: Starting batch simulation export for file 'SingleORAL_C11_4Comp_standard_standard_standard.json'
Information: Loading simulation 'SingleORAL_C11_4Comp_standard_standard_standard' (1/1)...
Information: 1 simulation found in file 'SingleORAL_C11_4Comp_standard_standard_standard.json'
Information: Starting batch simulation export for file 'SingleORAL_C12_4Comp_standard_schmitt_standard.json'
Information: Loading simulation 'SingleORAL_C12_4Comp_standard_schmitt_standard' (1/1)...
Information: 1 simulation found in file 'SingleORAL_C12_4Comp_standard_schmitt_standard.json'
Information: Starting batch simulation export for file 'SingleORAL_C13_4Comp_standard_schmittnormalized_standard.json'
Information: Loading simulation 'SingleORAL_C13_4Comp_standard_schmittnormalized_standard' (1/1)...
Information: 1 simulation found in file 'SingleORAL_C13_4Comp_standard_schmittnormalized_standard.json'
Information: Starting batch simulation export for file 'SingleORAL_C3_2Pores_standard_schmitt_standard.json'
Information: Loading simulation 'SingleORAL_C3_2Pores_standard_schmitt_standard' (1/1)...
Information: 1 simulation found in file 'SingleORAL_C3_2Pores_standard_schmitt_standard.json'
Information: Starting batch simulation export for file 'SingleORAL_C4_2Pores_standard_schmittnormalized_standard.json'
Information: Loading simulation 'SingleORAL_C4_2Pores_standard_schmittnormalized_standard' (1/1)...
Information: 1 simulation found in file 'SingleORAL_C4_2Pores_standard_schmittnormalized_standard.json'
Information: Starting batch simulation export for file 'SingleORAL_C6_4Comp_Ber_standard_standard.json'
Information: Loading simulation 'SingleORAL_C6_4Comp_Ber_standard_standard' (1/1)...
Information: 1 simulation found in file 'SingleORAL_C6_4Comp_Ber_standard_standard.json'
Information: Starting batch simulation export for file 'SingleORAL_C6_4Comp_RR_standard_standard.json'
Information: Loading simulation 'SingleORAL_C6_4Comp_RR_standard_standard' (1/1)...
Information: 1 simulation found in file 'SingleORAL_C6_4Comp_RR_standard_standard.json'
Information: Starting batch simulation export for file 'SingleORAL_C7_2Pores_Ber_standard_standard.json'
Information: Loading simulation 'SingleORAL_C7_2Pores_Ber_standard_standard' (1/1)...
Information: 1 simulation found in file 'SingleORAL_C7_2Pores_Ber_standard_standard.json'
Information: Starting batch simulation export for file 'SingleORAL_C7_4Comp_RR_schmitt_standard.json'
Information: Loading simulation 'SingleORAL_C7_4Comp_RR_schmitt_standard' (1/1)...
Information: 1 simulation found in file 'SingleORAL_C7_4Comp_RR_schmitt_standard.json'
Information: Starting batch simulation export for file 'Test 18.1_I1_C1_A1_Config1.json'
Information: Loading simulation 'Test 18.1_I1_C1_A1_Config1' (1/1)...
Information: 1 simulation found in file 'Test 18.1_I1_C1_A1_Config1.json'
Information: Starting batch simulation export for file 'Test 18.1_I2_C1_A1_Config2.json'
Information: Loading simulation 'Test 18.1_I2_C1_A1_Config2' (1/1)...
Information: 1 simulation found in file 'Test 18.1_I2_C1_A1_Config2.json'
Information: Starting batch simulation export for file 'Test 18.1_I2_C3_A1_Config2.json'
Information: Loading simulation 'Test 18.1_I2_C3_A1_Config2' (1/1)...
Information: 1 simulation found in file 'Test 18.1_I2_C3_A1_Config2.json'
Information: Starting batch simulation export for file 'Test 18.1_I3_C3_A3_Config2.json'
Information: Loading simulation 'Test 18.1_I3_C3_A3_Config2' (1/1)...
Information: 1 simulation found in file 'Test 18.1_I3_C3_A3_Config2.json'
Information: 182 simulations calculated and exported in 47m:35s:652ms
Information: Batch run finished: 2026-01-09 14:47

```</details> 