### PR TITLE
Fix build scripts for net10.0-windows output paths

### DIFF
--- a/InstallationValidator.sln
+++ b/InstallationValidator.sln
@@ -9,7 +9,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InstallationValidator.Tests
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{1EE126C4-E171-479C-B79A-0B5B1BBC50FC}"
 	ProjectSection(SolutionItems) = preProject
-		.github\workflows\build-nightly_12.3.yml = .github\workflows\build-nightly_12.3.yml
+		.github\workflows\build-nightly_13.0.yml = .github\workflows\build-nightly_13.0.yml
 		.github\workflows\build-and-test.yml = .github\workflows\build-and-test.yml
 		.github\workflows\codeql.yml = .github\workflows\codeql.yml
 		.github\workflows\coverage.yml = .github\workflows\coverage.yml

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Installation Validation Tool for the Open Systems Pharmacology Suite.
 
 ## Code Status
-[![Build status](https://img.shields.io/github/actions/workflow/status/Open-Systems-Pharmacology/InstallationValidator/nightly-badge.yml?logo=GitHub&label=Build%20status)](https://github.com/Open-Systems-Pharmacology/InstallationValidator/actions/workflows/build-nightly.yml)
+[![Build status](https://img.shields.io/github/actions/workflow/status/Open-Systems-Pharmacology/InstallationValidator/nightly-badge.yml?logo=GitHub&label=Build%20status)](https://github.com/Open-Systems-Pharmacology/InstallationValidator/actions/workflows/build-nightly_13.0.yml)
 [![Coverage status](https://codecov.io/gh/Open-Systems-Pharmacology/InstallationValidator/branch/develop/graph/badge.svg)](https://codecov.io/gh/Open-Systems-Pharmacology/InstallationValidator)
 
 ## Wix Install 

--- a/dotcover.xml
+++ b/dotcover.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
   <TargetArguments>
-    tests\InstallationValidator.Tests\bin\Debug\net472\InstallationValidator.Tests.dll
+    tests\InstallationValidator.Tests\bin\Debug\net10.0-windows\InstallationValidator.Tests.dll
   </TargetArguments>
   <TargetWorkingDir>./</TargetWorkingDir>
  

--- a/rakefile.rb
+++ b/rakefile.rb
@@ -43,7 +43,7 @@ task :postclean do |t, args|
 	src_dir =  src_dir_for("Debug")
 
 	all_users_dir = ENV['ALLUSERSPROFILE']
-	all_users_application_dir = File.join(all_users_dir, manufacturer, product_name, '12.3')
+	all_users_application_dir = File.join(all_users_dir, manufacturer, product_name, '13.0')
 
 	copy_dependencies solution_dir,  all_users_application_dir do
 		copy_dimensions_xml
@@ -57,7 +57,7 @@ end
 private
 
 def relative_src_dir_for(configuration)
-	File.join('src', 'InstallationValidator', 'bin', configuration, 'net472')
+	File.join('src', 'InstallationValidator', 'bin', configuration, 'net10.0-windows')
 end
 
 def src_dir_for(configuration)


### PR DESCRIPTION
Fixes #339

The `Build Nightly 13.0` workflow failed at the `Create Setup` step:

```
Errno::ENOENT: No such file or directory @ apply2files - .../setup/deploy/harvest/InstallationValidator.exe
```

The projects target `net10.0-windows`, but the build scripts still referenced the old `net472` output folder.

- **rakefile.rb**: harvest source `bin/<config>/net472` -> `net10.0-windows` (fixes the failure), and the `postclean` data folder `12.3` -> `13.0`.
- **dotcover.xml**: coverage target dll path `net472` -> `net10.0-windows`.
- **InstallationValidator.sln**: solution-folder reference to the renamed nightly (`build-nightly_12.3.yml` -> `build-nightly_13.0.yml`).

After this merges, re-run `Build Nightly 13.0` to produce the "Installation Validator Installer 13.0.x" artifact the Suite build needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)