### PR TITLE
Remove dead OSPSuite.TeXReporting references from setup

### DIFF
--- a/rakefile.rb
+++ b/rakefile.rb
@@ -18,7 +18,6 @@ task :create_setup, [:product_version, :configuration] do |t, args|
 
 	#Files required for setup creation only and that will not be harvested automatically
 	setup_files	 = [
-		"#{relative_src_dir}/TeXTemplates/**/*.*",
 		'data/*.wxs',
 		'src/InstallationValidator/*.ico',
 		'dimensions/*.xml',
@@ -47,10 +46,6 @@ task :postclean do |t, args|
 
 	copy_dependencies solution_dir,  all_users_application_dir do
 		copy_dimensions_xml
-	end
-
-	copy_dependencies src_dir,  File.join(all_users_application_dir, 'TeXTemplates', 'StandardTemplate') do
-		copy_files 'StandardTemplate', '*'
 	end
 end
 

--- a/setup/setup.wxs
+++ b/setup/setup.wxs
@@ -58,13 +58,6 @@
                 <File Name='OSPSuite.Dimensions.xml' Id='OSPSuite.Dimensions' Source='$(var.DeployDir)/OSPSuite.Dimensions.xml' KeyPath='yes' />
               </Component>
   
-              <Directory Id="TeXTemplatesFolder" Name="TeXTemplates">
-                <Component Id="TeXTemplatesFolder" Guid="2EA58178-7B6C-4F6C-8ACD-7AD0D49D7723">
-                  <CreateFolder Directory="TeXTemplatesFolder">
-                    <Permission User="Everyone" GenericAll="yes" />
-                  </CreateFolder>
-                </Component>
-              </Directory>
 
             </Directory>
           </Directory>
@@ -94,7 +87,6 @@
 
     <Feature Id="Main" Title="$(var.ProductName)" Level="1" Absent="disallow" AllowAdvertise="no">
       <ComponentGroupRef Id="App" />
-      <ComponentGroupRef Id="OSPSuite.TeXReporting" />
       <ComponentGroupRef Id="BatchFiles" />
 
       <ComponentRef Id="InstallationValidator.exe" />
@@ -102,7 +94,6 @@
       <ComponentRef Id="OSPSuiteDataFolder" />
       <ComponentRef Id="InstallationValidatorCommonDataFolder" />
       <ComponentRef Id="InstallationValidatorCommonDataVersionFolder" />
-      <ComponentRef Id="TeXTemplatesFolder" />
       <ComponentRef Id="OSPSuite.Dimensions" />
     </Feature>
 


### PR DESCRIPTION
Fixes #340

The `Build Nightly 13.0` setup build failed at WiX `light.exe`:

```
setup.wxs(97) : error LGHT0094 : Unresolved reference to symbol 'WixComponentGroup:OSPSuite.TeXReporting'
```

TeX/LaTeX reporting was replaced with Markdown + QuestPDF in #325, which removed the `OSPSuite.TeXReporting` dependency but left the setup referencing it. This only surfaced on the first 13.0 setup build (12.3 still shipped TeXReporting).

Removed the dead references:
- `setup/setup.wxs`: `ComponentGroupRef Id="OSPSuite.TeXReporting"`, the `TeXTemplatesFolder` directory/component, and its `ComponentRef`
- `rakefile.rb`: the `TeXTemplates/**/*.*` harvest glob and the `postclean` TeXTemplates copy

`<Directory>` tags remain balanced (9/9) and no dangling `TeXTemplatesFolder` references remain.

After merge, re-run `Build Nightly 13.0` to produce the "Installation Validator Installer 13.0.x" artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated installation packaging to prevent unnecessary TeX template files and folders from being included.
  * Improved post-clean dependency copying and dimension configuration handling.
  * Ensured batch files remain included in the installer while removing obsolete template components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->