### PR TITLE
Run Reporting tests in CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,4 +18,3 @@ jobs:
     secrets: inherit
     with:
       temp-version: "13.0.9999"
-      test-arguments: "--filter TestCategory!=Reporting"

--- a/.github/workflows/build-nightly_13.0.yml
+++ b/.github/workflows/build-nightly_13.0.yml
@@ -61,7 +61,7 @@ jobs:
           dotnet build InstallationValidator.sln /p:Version=${{env.APP_VERSION}}
 
       - name: Test
-        run: dotnet test InstallationValidator.sln --filter "TestCategory!=Reporting" --no-build -v normal  --logger:"html;LogFileName=${{ github.workspace }}/testLog_Windows.html"
+        run: dotnet test InstallationValidator.sln --no-build -v normal  --logger:"html;LogFileName=${{ github.workspace }}/testLog_Windows.html"
 
       - name: Sign InstallationValidator.exe with CodeSignTool
         uses: Open-Systems-Pharmacology/Workflows/.github/actions/codesigner-SSL@main


### PR DESCRIPTION
Fixes #342

The `--filter TestCategory!=Reporting` exclusion (in `build-and-test.yml` and `build-nightly_13.0.yml`) was added in #287 when reporting used MiKTeX/LaTeX, which isn't installed on the CI runners. #325 replaced reporting with Markdown + QuestPDF (pure .NET, no external dependency), so the `[Category("Reporting")]` tests can now run headlessly.

Dropped the filter from both workflows so the reporting tests run in CI. This also serves as the runtime verification that QuestPDF/Markdown reporting works on the .NET 10 line — if any reporting test fails here, that's a real gap to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)